### PR TITLE
Fix: 프로파일 별 OAuth2 Redirect URI 설정

### DIFF
--- a/library-auth/src/main/java/com/onetuks/libraryauth/jwt/filter/JwtAuthenticationFilter.java
+++ b/library-auth/src/main/java/com/onetuks/libraryauth/jwt/filter/JwtAuthenticationFilter.java
@@ -61,11 +61,19 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
           request.getRequestURL(),
           request.getHeader(AuthHeaderUtil.HEADER_AUTHORIZATION));
     } catch (RuntimeException e) {
-      boolean isActuatorRequest = request.getRequestURL().toString().contains("actuator");
+      boolean isAuthPermittedAccess =
+          Arrays.stream(AuthPermittedEndpoint.ENDPOINTS)
+              .anyMatch(endpoint -> request.getRequestURL().toString().contains(endpoint));
 
-      if (!isActuatorRequest) {
+      if (!isAuthPermittedAccess) {
         log.warn(
-            "JWT 토큰 검증 중 오류가 발생했습니다. (비정상적인 접근일 가능성이 있습니다.) - URL: {} / Header: {} / Exception: {}",
+            "[인증] JWT 토큰 검증 중 오류가 발생했습니다. (비정상적인 접근일 가능성이 있습니다.) - URL: {} / Header: {} / Exception: {}",
+            request.getRequestURL(),
+            request.getHeader(AuthHeaderUtil.HEADER_AUTHORIZATION),
+            e.getMessage());
+      } else {
+        log.info(
+            "[인증] 비인증 API 요청입니다. - URL: {} / Header: {} / Exception: {}",
             request.getRequestURL(),
             request.getHeader(AuthHeaderUtil.HEADER_AUTHORIZATION),
             e.getMessage());

--- a/library-auth/src/main/java/com/onetuks/libraryauth/oauth/config/GoogleClientConfig.java
+++ b/library-auth/src/main/java/com/onetuks/libraryauth/oauth/config/GoogleClientConfig.java
@@ -18,13 +18,16 @@ public class GoogleClientConfig {
   @Value("${oauth.google.client-secret}")
   private String clientSecret;
 
+  @Value("${oauth.google.redirect-uri}")
+  private String redirectUri;
+
   public ClientRegistration googleClientRegistration() {
     return ClientRegistration.withRegistrationId("google")
         .clientId(clientId)
         .clientSecret(clientSecret)
         .clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_BASIC)
         .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
-        .redirectUri("http://localhost:8000/login/oauth2/callback/google")
+        .redirectUri(redirectUri)
         .scope("profile", "email")
         .authorizationUri("https://accounts.google.com/o/oauth2/v2/auth")
         .tokenUri("https://www.googleapis.com/oauth2/v4/token")

--- a/library-auth/src/main/java/com/onetuks/libraryauth/oauth/config/KakaoClientConfig.java
+++ b/library-auth/src/main/java/com/onetuks/libraryauth/oauth/config/KakaoClientConfig.java
@@ -16,12 +16,15 @@ public class KakaoClientConfig {
   @Value("${oauth.kakao.client-secret}")
   private String clientSecret;
 
+  @Value("${oauth.kakao.redirect-uri}")
+  private String redirectUri;
+
   public ClientRegistration kakaoClientRegistration() {
     return ClientRegistration.withRegistrationId("kakao")
         .clientId(clientId)
         .clientSecret(clientSecret)
         .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
-        .redirectUri("http://localhost:8000/login/oauth2/callback/kakao")
+        .redirectUri(redirectUri)
         .authorizationUri("https://kauth.kakao.com/oauth/authorize")
         .tokenUri("https://kauth.kakao.com/oauth/token")
         .userInfoUri("https://kapi.kakao.com/v2/user/me")

--- a/library-auth/src/main/java/com/onetuks/libraryauth/oauth/config/NaverClientConfig.java
+++ b/library-auth/src/main/java/com/onetuks/libraryauth/oauth/config/NaverClientConfig.java
@@ -16,12 +16,15 @@ public class NaverClientConfig {
   @Value("${oauth.naver.client_secret}")
   private String clientSecret;
 
+  @Value("${oauth.naver.redirect-uri}")
+  private String redirectUri;
+
   public ClientRegistration naverClientRegistration() {
     return ClientRegistration.withRegistrationId("naver")
         .clientId(clientId)
         .clientSecret(clientSecret)
         .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
-        .redirectUri("http://localhost:8000/login/oauth2/callback/naver")
+        .redirectUri(redirectUri)
         .authorizationUri("https://nid.naver.com/oauth2.0/authorize")
         .tokenUri("https://nid.naver.com/oauth2.0/token")
         .userInfoUri("https://openapi.naver.com/v1/nid/me")


### PR DESCRIPTION
# 변경 내용
- OAuth2 Redirect URI가 로컬 환경으로 하드코딩되어 있었음
- 프로파일 별로 로컬 / 상용 URI 로 리디렉션 가능토록 주입
- 인증 허용 엔드포인트도 요청 헤더 검증 로깅에서 예외 캐치하던 현상을 방지